### PR TITLE
Replace forkIO with race

### DIFF
--- a/hydra-github-bridge/hydra-github-bridge.cabal
+++ b/hydra-github-bridge/hydra-github-bridge.cabal
@@ -15,6 +15,7 @@ common common
     build-depends:    base >=4.16 && < 5
                     , aeson
                     , aeson-casing
+                    , async
                     , human-readable-duration
                     , postgresql-simple
                     , bytestring


### PR DESCRIPTION
The `forkIO` function silently swallows a number of important exceptions (like `ThreadKilled`) so replace it with `Control.Concurrent.Async.race` and report which thread exited.