### PR TITLE
Fix various small issues in NixOS module

### DIFF
--- a/flake/nixosModules.nix
+++ b/flake/nixosModules.nix
@@ -264,8 +264,6 @@
 
                 export HYDRA_STATE_DIR="$STATE_DIRECTORY"
 
-                mkdir -p "$QUEUE_DIR"
-
                 exec ${lib.getExe iCfg.package}
               '';
             }


### PR DESCRIPTION
 1. Compare `ghAppKeyFile` with `null` (not `""`)
 2. Compare `hydraPassFile` with `null` (not `""`)
 3. Compare `ghAppInstallIds` with `"[]"` (not `[]`)
 4. Remove reference to now-defunct `QUEUE_DIR`

For more context, look at:

 * https://github.com/input-output-hk/hydra-tools/pull/8#discussion_r2624667134
 * https://github.com/input-output-hk/hydra-tools/pull/8#discussion_r2624682958
 * https://github.com/input-output-hk/hydra-tools/pull/8#discussion_r2624684008
 * https://github.com/input-output-hk/hydra-tools/pull/8#discussion_r2624689151