### PR TITLE
Add back the check run prefix "ci/hydra-build"

### DIFF
--- a/hydra-github-bridge/app/Main.hs
+++ b/hydra-github-bridge/app/Main.hs
@@ -192,7 +192,7 @@ handleHydraNotification conn host stateDir e = (\computation -> catchJust catchJ
         singleton $
           GitHub.CheckRun owner repo $
             GitHub.CheckRunPayload
-              { name = job,
+              { name = "ci/hydra-build:" <> job,
                 headSha = hash,
                 detailsUrl = Just $ "https://" <> host <> "/build/" <> tshow bid,
                 externalId = Just $ tshow bid,
@@ -214,7 +214,7 @@ handleHydraNotification conn host stateDir e = (\computation -> catchJust catchJ
         singleton $
           GitHub.CheckRun owner repo $
             GitHub.CheckRunPayload
-              { name = job,
+              { name = "ci/hydra-build:" <> job,
                 headSha = hash,
                 detailsUrl = Just $ "https://" <> host <> "/build/" <> tshow bid,
                 externalId = Just $ tshow bid,
@@ -416,7 +416,7 @@ handleHydraNotification conn host stateDir e = (\computation -> catchJust catchJ
           singleton $
             GitHub.CheckRun owner repo $
               GitHub.CheckRunPayload
-                { name = job,
+                { name = "ci/hydra-build:" <> job,
                   headSha = hash,
                   detailsUrl = Just $ "https://" <> host <> "/build/" <> tshow bid,
                   externalId = Just $ tshow bid,


### PR DESCRIPTION
Revert "drop ci/hydra-build."

This reverts commit ee940020aa2baecf8b08754908fabc3e85a78715.

Most repos in IntersectMBO have required PR checks on statuses "ci/hydra-build.xyz.required", and dropping that prefix would break them.