### PR TITLE
systemd dependency ordering

### DIFF
--- a/flake/nixosModules.nix
+++ b/flake/nixosModules.nix
@@ -124,102 +124,106 @@
                 '';
               };
 
-              waitForHydraServerPort = mkEnableOption ''
-                delay of hydra-server started state until its port is ready.
-                Note this adds an ExecStartPost= to hydra-server.
-                It does not make the hydra-github-bridge wait as the same might suggest.
-              '' // {
-                default = true;
-              };
+              waitForHydraServerPort =
+                mkEnableOption ''
+                  delay of hydra-server started state until its port is ready.
+                  Note this adds an ExecStartPost= to hydra-server.
+                  It does not make the hydra-github-bridge wait as the same might suggest.
+                ''
+                // {
+                  default = true;
+                };
             };
           });
         };
 
       config.systemd = lib.mkIf (cfg != {}) {
-        services = lib.flip lib.mapAttrs' cfg (
-          name: iCfg:
-            lib.nameValuePair "hydra-github-bridge-${name}" {
-              inherit (iCfg) enable;
+        services =
+          lib.flip lib.mapAttrs' cfg (
+            name: iCfg:
+              lib.nameValuePair "hydra-github-bridge-${name}" {
+                inherit (iCfg) enable;
 
-              wantedBy = ["hydra-github-bridge.target"];
-              after = ["postgresql.service"] ++ config.systemd.targets.hydra-github-bridge.after;
-              partOf = ["hydra-github-bridge.target"];
+                wantedBy = ["hydra-github-bridge.target"];
+                after = ["postgresql.service"] ++ config.systemd.targets.hydra-github-bridge.after;
+                partOf = ["hydra-github-bridge.target"];
 
-              startLimitIntervalSec = 0;
+                startLimitIntervalSec = 0;
 
-              serviceConfig =
-                {
-                  User = config.users.users.hydra.name;
-                  Group = config.users.groups.hydra.name;
+                serviceConfig =
+                  {
+                    User = config.users.users.hydra.name;
+                    Group = config.users.groups.hydra.name;
 
-                  Restart = "always";
-                  RestartSec = "10s";
+                    Restart = "always";
+                    RestartSec = "10s";
 
-                  LoadCredential =
-                    lib.optional (iCfg.ghTokenFile != null) "github-token:${iCfg.ghTokenFile}"
-                    ++ lib.optional (iCfg.ghAppKeyFile != null) "github-app-key-file:${iCfg.ghAppKeyFile}"
-                    ++ lib.optional (iCfg.hydraPassFile != null) "hydra-pass:${iCfg.hydraPassFile}"
-                    ++ lib.optional (iCfg.ghSecretFile != null) "github-secret:${iCfg.ghSecretFile}";
+                    LoadCredential =
+                      lib.optional (iCfg.ghTokenFile != null) "github-token:${iCfg.ghTokenFile}"
+                      ++ lib.optional (iCfg.ghAppKeyFile != null) "github-app-key-file:${iCfg.ghAppKeyFile}"
+                      ++ lib.optional (iCfg.hydraPassFile != null) "hydra-pass:${iCfg.hydraPassFile}"
+                      ++ lib.optional (iCfg.ghSecretFile != null) "github-secret:${iCfg.ghSecretFile}";
 
-                  StateDirectory = "hydra";
-                }
-                // lib.optionalAttrs (iCfg.environmentFile != null)
-                {EnvironmentFile = builtins.toPath iCfg.environmentFile;};
+                    StateDirectory = "hydra";
+                  }
+                  // lib.optionalAttrs (iCfg.environmentFile != null)
+                  {EnvironmentFile = builtins.toPath iCfg.environmentFile;};
 
-              environment =
-                {
-                  HYDRA_HOST = iCfg.hydraHost;
-                  HYDRA_DB = iCfg.hydraDb;
-                  PORT = toString iCfg.port;
-                }
-                // lib.optionalAttrs (iCfg.ghUserAgent != "") {
-                  GITHUB_USER_AGENT = iCfg.ghUserAgent;
-                }
-                // lib.optionalAttrs (iCfg.ghAppId != 0) {
-                  GITHUB_APP_ID = toString iCfg.ghAppId;
-                }
-                // lib.optionalAttrs (iCfg.ghAppInstallIds != {}) {
-                  GITHUB_APP_INSTALL_IDS = let
-                    mkPairStr = org: installId: "${org}=${builtins.toString installId}";
-                  in
-                    lib.pipe iCfg.ghAppInstallIds [
-                      (lib.mapAttrsToList mkPairStr)
-                      (lib.concatStringsSep ",")
-                    ];
-                }
-                // lib.optionalAttrs (iCfg.hydraUser != "") {
-                  HYDRA_USER = iCfg.hydraUser;
-                };
+                environment =
+                  {
+                    HYDRA_HOST = iCfg.hydraHost;
+                    HYDRA_DB = iCfg.hydraDb;
+                    PORT = toString iCfg.port;
+                  }
+                  // lib.optionalAttrs (iCfg.ghUserAgent != "") {
+                    GITHUB_USER_AGENT = iCfg.ghUserAgent;
+                  }
+                  // lib.optionalAttrs (iCfg.ghAppId != 0) {
+                    GITHUB_APP_ID = toString iCfg.ghAppId;
+                  }
+                  // lib.optionalAttrs (iCfg.ghAppInstallIds != {}) {
+                    GITHUB_APP_INSTALL_IDS = let
+                      mkPairStr = org: installId: "${org}=${builtins.toString installId}";
+                    in
+                      lib.pipe iCfg.ghAppInstallIds [
+                        (lib.mapAttrsToList mkPairStr)
+                        (lib.concatStringsSep ",")
+                      ];
+                  }
+                  // lib.optionalAttrs (iCfg.hydraUser != "") {
+                    HYDRA_USER = iCfg.hydraUser;
+                  };
 
-              script = ''
-                ${lib.optionalString (iCfg.ghTokenFile != null) ''export GITHUB_WEBHOOK_SECRET=$(< "$CREDENTIALS_DIRECTORY"/github-token)''}
-                ${lib.optionalString (iCfg.ghAppKeyFile != null) ''export GITHUB_APP_KEY_FILE="$CREDENTIALS_DIRECTORY"/github-app-key-file''}
-                ${lib.optionalString (iCfg.hydraPassFile != null) ''export HYDRA_PASS=$(< "$CREDENTIALS_DIRECTORY"/hydra-pass)''}
-                ${lib.optionalString (iCfg.ghSecretFile != null) ''export KEY=$(< "$CREDENTIALS_DIRECTORY"/github-secret)''}
+                script = ''
+                  ${lib.optionalString (iCfg.ghTokenFile != null) ''export GITHUB_WEBHOOK_SECRET=$(< "$CREDENTIALS_DIRECTORY"/github-token)''}
+                  ${lib.optionalString (iCfg.ghAppKeyFile != null) ''export GITHUB_APP_KEY_FILE="$CREDENTIALS_DIRECTORY"/github-app-key-file''}
+                  ${lib.optionalString (iCfg.hydraPassFile != null) ''export HYDRA_PASS=$(< "$CREDENTIALS_DIRECTORY"/hydra-pass)''}
+                  ${lib.optionalString (iCfg.ghSecretFile != null) ''export KEY=$(< "$CREDENTIALS_DIRECTORY"/github-secret)''}
 
-                export HYDRA_STATE_DIR="$STATE_DIRECTORY"
+                  export HYDRA_STATE_DIR="$STATE_DIRECTORY"
 
-                exec ${lib.getExe iCfg.package}
-              '';
-            }
-        ) // lib.optionalAttrs (lib.any (iCfg: iCfg.waitForHydraServerPort) (lib.attrValues cfg)) {
-          # Delay systemd's dependencies until Hydra actually listens.
-          # This is needed for After= ordering of the github-hydra-bridge
-          # because that tries to log in to use Hydra's API when it starts.
-          hydra-server.postStart = let
-            script = pkgs.writeShellApplication {
-              name = "hydra-wait-for-port";
-              runtimeInputs = [pkgs.netcat];
-              text = ''
-                while ! nc -z localhost ${toString config.services.hydra.port} 2> /dev/null; do
-                  sleep 1
-                done
-              '';
-            };
-          in ''
-            timeout 30 ${lib.getExe script}
-          '';
-        };
+                  exec ${lib.getExe iCfg.package}
+                '';
+              }
+          )
+          // lib.optionalAttrs (lib.any (iCfg: iCfg.waitForHydraServerPort) (lib.attrValues cfg)) {
+            # Delay systemd's dependencies until Hydra actually listens.
+            # This is needed for After= ordering of the github-hydra-bridge
+            # because that tries to log in to use Hydra's API when it starts.
+            hydra-server.postStart = let
+              script = pkgs.writeShellApplication {
+                name = "hydra-wait-for-port";
+                runtimeInputs = [pkgs.netcat];
+                text = ''
+                  while ! nc -z localhost ${toString config.services.hydra.port} 2> /dev/null; do
+                    sleep 1
+                  done
+                '';
+              };
+            in ''
+              timeout 30 ${lib.getExe script}
+            '';
+          };
 
         targets.hydra-github-bridge = rec {
           wantedBy = ["hydra-server.service"];

--- a/flake/nixosModules.nix
+++ b/flake/nixosModules.nix
@@ -123,6 +123,14 @@
                   plaintext environment file, containing and `HYDRA_DB_USER`, and `HYDRA_DB_PASS`.
                 '';
               };
+
+              waitForHydraServerPort = mkEnableOption ''
+                delay of hydra-server started state until its port is ready.
+                Note this adds an ExecStartPost= to hydra-server.
+                It does not make the hydra-github-bridge wait as the same might suggest.
+              '' // {
+                default = true;
+              };
             };
           });
         };
@@ -134,7 +142,7 @@
               inherit (iCfg) enable;
 
               wantedBy = ["hydra-github-bridge.target"];
-              after = ["postgresql.service"];
+              after = ["postgresql.service"] ++ config.systemd.targets.hydra-github-bridge.after;
               partOf = ["hydra-github-bridge.target"];
 
               startLimitIntervalSec = 0;
@@ -194,9 +202,29 @@
                 exec ${lib.getExe iCfg.package}
               '';
             }
-        );
+        ) // lib.optionalAttrs (lib.any (iCfg: iCfg.waitForHydraServerPort) (lib.attrValues cfg)) {
+          # Delay systemd's dependencies until Hydra actually listens.
+          # This is needed for After= ordering of the github-hydra-bridge
+          # because that tries to log in to use Hydra's API when it starts.
+          hydra-server.postStart = let
+            script = pkgs.writeShellApplication {
+              name = "hydra-wait-for-port";
+              runtimeInputs = [pkgs.netcat];
+              text = ''
+                while ! nc -z localhost ${toString config.services.hydra.port} 2> /dev/null; do
+                  sleep 1
+                done
+              '';
+            };
+          in ''
+            timeout 30 ${lib.getExe script}
+          '';
+        };
 
-        targets.hydra-github-bridge.wantedBy = ["hydra-server.service"];
+        targets.hydra-github-bridge = rec {
+          wantedBy = ["hydra-server.service"];
+          after = wantedBy;
+        };
       };
     });
 

--- a/flake/packages/fake-send-webhook/default.nix
+++ b/flake/packages/fake-send-webhook/default.nix
@@ -1,4 +1,4 @@
-{...}: {
+{
   perSystem = {
     config,
     pkgs,
@@ -13,16 +13,16 @@
       # Usage:
       # WEBHOOK_SECRET=TOPSECRET fake-send-webhook http://hydra-bridge.example.com EVENT < payload.txt
       text = ''
-        WEBHOOK_SECRET="''${WEBHOOK_SECRET:-TOPSECRET}"
-        HOOK_URL="''${1:-http://localhost:8811}"
-        EVENT="''${2:-pull_request}"
+        WEBHOOK_SECRET=''${WEBHOOK_SECRET:-TOPSECRET}
+        HOOK_URL=''${1:-http://localhost:8811}
+        EVENT=''${2:-pull_request}
         tmp=$(mktemp webhook.XXXX)
 
         jq --compact-output . \
           | tr -d "\n" \
-          > "''$tmp"
+          > "$tmp"
 
-        SHA1_SIG=$(openssl dgst -r -sha1 -hmac "$WEBHOOK_SECRET" "''$tmp" | awk '{print ''$1}')
+        SHA1_SIG=$(openssl dgst -r -sha1 -hmac "$WEBHOOK_SECRET" "$tmp" | awk '{print $1}')
 
         curl \
           -i \
@@ -33,11 +33,11 @@
           -H "X-GitHub-Hook-Installation-Target-ID: 98765" \
           -H "X-GitHub-Hook-Installation-Target-Type: integration" \
           -H "X-Hub-Signature: sha1=''${SHA1_SIG}" \
-          -d "@''${tmp}" \
+          -d "@$tmp" \
           --fail \
           "$HOOK_URL"
 
-        rm "''$tmp"
+        rm "$tmp"
       '';
     };
 

--- a/flake/packages/mockoon-cli/default.nix
+++ b/flake/packages/mockoon-cli/default.nix
@@ -1,10 +1,4 @@
 {
-  inputs,
-  config,
-  lib,
-  withSystem,
-  ...
-}: {
   perSystem = {
     config,
     pkgs,
@@ -61,6 +55,8 @@
           $out/lib/node_modules/@mockoon/mockoon/node_modules/@mockoon/cli/bin/run.js \
           $out/bin/mockoon-cli
       '';
+
+      meta.mainProgram = "mockoon-cli";
     };
   };
 }

--- a/flake/test/default.nix
+++ b/flake/test/default.nix
@@ -50,17 +50,22 @@
           testScript = ''
             start_all()
 
+            # The bridge needs its Hydra user to be created first
+            hydra.systemctl("stop hydra-github-bridge.target")
+
             # Wait for Hydra to start
             hydra.wait_for_unit("hydra-server.service")
             hydra.wait_for_open_port(3000)
+
+            # Create the bridge user and start the bridge
             hydra.succeed("hydra-create-user bridge --password hydra --role admin")
+            hydra.systemctl("start hydra-github-bridge.target")
 
             # Wait for GitHub Mock server
             hydra.wait_for_unit("mock-github.service")
             hydra.wait_for_open_port(4010)
 
-            # Start hydra-github-bridge
-            hydra.systemctl("start hydra-github-bridge-all.service")
+            # Wait for hydra-github-bridge
             hydra.wait_for_unit("hydra-github-bridge-all.service")
             hydra.wait_for_open_port(8811, timeout=15)
 

--- a/flake/test/default.nix
+++ b/flake/test/default.nix
@@ -5,7 +5,7 @@
     system,
     lib,
     ...
-  } @ perSystem:
+  }:
     lib.optionalAttrs (system == "x86_64-linux") {
       checks.test = let
         prOpenedPayload = ./pr_opened.payload.txt;

--- a/flake/test/setup.nix
+++ b/flake/test/setup.nix
@@ -89,12 +89,10 @@
       in "${mockoonBin} start --data ${mockData} --port 4010 --repair";
     };
 
-    hydra-github-bridge-all = {
-      # These will fail until Hydra and Mock GitHub are running, so we'll start
-      # them manually
-      wantedBy = lib.mkForce [];
-      # We'll want the test to fail if they crash
-      serviceConfig.Restart = lib.mkForce "no";
-    };
+    # We'll want the test to fail if they crash
+    hydra-github-bridge-all.serviceConfig.Restart = lib.mkForce "no";
   };
+
+  # These will fail until Hydra and Mock GitHub are running
+  systemd.targets.hydra-github-bridge.after = ["mock-github.service"];
 }

--- a/flake/test/setup.nix
+++ b/flake/test/setup.nix
@@ -84,7 +84,7 @@
     mock-github = {
       wantedBy = ["multi-user.target"];
       serviceConfig.ExecStart = let
-        mockoonBin = "${flakePackages.mockoon-cli}/bin/mockoon-cli";
+        mockoonBin = lib.getExe flakePackages.mockoon-cli;
         mockData = ../../mock-github-data.json;
       in "${mockoonBin} start --data ${mockData} --port 4010 --repair";
     };


### PR DESCRIPTION
This adds a waitForHydraServerPort option that adds an ExecStartPost= to hydra-server so that its systemd dependencies ordered After= it wait for the port to become ready.

Some trivial simplifications from reviewing prior PRs are also included.