### PR TITLE
Optimize multi-instance support

### DIFF
--- a/flake/nixosModules.nix
+++ b/flake/nixosModules.nix
@@ -8,226 +8,211 @@
     }: let
       cfg = config.services.hydra-github-bridge;
     in {
-      options.services.hydra-github-bridge = with lib;
-        mkOption {
-          type = types.attrsOf (types.submodule {
-            options = {
-              enable =
-                mkEnableOption "hydra github bridge"
-                // {
-                  default = true;
-                };
-
-              package = mkOption {
-                type = types.package;
-                default = perSystem.config.packages.hydra-github-bridge;
-                defaultText = "hydra-github-bridge";
-                description = "The hydra to github webhook bridge";
-              };
-
-              ghAppId = mkOption {
-                type = types.int;
-                default = 0;
-                description = ''
-                  The GitHub App ID to sign authentication JWTs with.
-                '';
-              };
-
-              ghAppInstallIds = mkOption {
-                type = types.attrsOf types.int;
-                default = {};
-                description = ''
-                  Mapping of organization names to GitHub App installation ids to
-                  authenticate with.
-                '';
-              };
-
-              ghUserAgent = mkOption {
-                type = types.str;
-                default = null;
-                description = ''
-                  The user agent to use for authorization with the GitHub API.
-                  This must match the app name if you authenticate using a GitHub App token.
-                '';
-              };
-
-              ghAppKeyFile = mkOption {
-                type = types.path;
-                default = "";
-                description = ''
-                  Path to a file containing the GitHub App private key for authorization with GitHub.
-                '';
-              };
-
-              ghTokenFile = mkOption {
-                type = with types; nullOr path;
-                default = null;
-                description = ''
-                  Path to a file containing the GitHub token for authorization with GitHub.
-                '';
-              };
-
-              ghSecretFile = mkOption {
-                type = types.nullOr types.path;
-                default = null;
-                description = ''
-                  The agreed upon secret with GitHub for the Webhook payloads.
-                '';
-              };
-
-              hydraHost = mkOption {
-                type = types.str;
-                example = "http://hydra.example.com:8080";
-                default = "localhost";
-                description = ''
-                  The host or URL of hydra.
-                '';
-              };
-
-              hydraUser = mkOption {
-                type = types.str;
-                default = "";
-                description = ''
-                  The user to authenticate as with hydra.
-                '';
-              };
-
-              hydraPassFile = mkOption {
-                type = types.nullOr types.path;
-                default = null;
-                description = ''
-                  A file containing the password to authenticate with against hydra.
-                '';
-              };
-
-              hydraDb = mkOption {
-                type = types.str;
-                default = "";
-                description = ''
-                  Hydra DB host string. Empty means unix socket.
-                '';
-              };
-
-              port = mkOption {
-                type = types.port;
-                default = 8811;
-                description = ''
-                  The port to listen on for webhooks.
-                '';
-              };
-
-              environmentFile = mkOption {
-                type = types.nullOr types.path;
-                default = null;
-                description = ''
-                  plaintext environment file, containing and `HYDRA_DB_USER`, and `HYDRA_DB_PASS`.
-                '';
-              };
-
-              waitForHydraServerPort =
-                mkEnableOption ''
-                  delay of hydra-server started state until its port is ready.
-                  Note this adds an ExecStartPost= to hydra-server.
-                  It does not make the hydra-github-bridge wait as the name might suggest.
-                ''
-                // {
-                  default = true;
-                };
-            };
-          });
-        };
-
-      config.systemd = lib.mkIf (cfg != {}) {
-        services =
-          lib.flip lib.mapAttrs' cfg (
-            name: iCfg:
-              lib.nameValuePair "hydra-github-bridge-${name}" {
-                inherit (iCfg) enable;
-
-                wantedBy = ["hydra-github-bridge.target"];
-                after = ["postgresql.service"] ++ config.systemd.targets.hydra-github-bridge.after;
-                partOf = ["hydra-github-bridge.target"];
-
-                startLimitIntervalSec = 0;
-
-                serviceConfig =
-                  {
-                    User = config.users.users.hydra.name;
-                    Group = config.users.groups.hydra.name;
-
-                    Restart = "always";
-                    RestartSec = "10s";
-
-                    LoadCredential =
-                      lib.optional (iCfg.ghTokenFile != null) "github-token:${iCfg.ghTokenFile}"
-                      ++ lib.optional (iCfg.ghAppKeyFile != null) "github-app-key-file:${iCfg.ghAppKeyFile}"
-                      ++ lib.optional (iCfg.hydraPassFile != null) "hydra-pass:${iCfg.hydraPassFile}"
-                      ++ lib.optional (iCfg.ghSecretFile != null) "github-secret:${iCfg.ghSecretFile}";
-
-                    StateDirectory = "hydra";
-                  }
-                  // lib.optionalAttrs (iCfg.environmentFile != null)
-                  {EnvironmentFile = builtins.toPath iCfg.environmentFile;};
-
-                environment =
-                  {
-                    HYDRA_HOST = iCfg.hydraHost;
-                    HYDRA_DB = iCfg.hydraDb;
-                    PORT = toString iCfg.port;
-                  }
-                  // lib.optionalAttrs (iCfg.ghUserAgent != "") {
-                    GITHUB_USER_AGENT = iCfg.ghUserAgent;
-                  }
-                  // lib.optionalAttrs (iCfg.ghAppId != 0) {
-                    GITHUB_APP_ID = toString iCfg.ghAppId;
-                  }
-                  // lib.optionalAttrs (iCfg.ghAppInstallIds != {}) {
-                    GITHUB_APP_INSTALL_IDS = let
-                      mkPairStr = org: installId: "${org}=${builtins.toString installId}";
-                    in
-                      lib.pipe iCfg.ghAppInstallIds [
-                        (lib.mapAttrsToList mkPairStr)
-                        (lib.concatStringsSep ",")
-                      ];
-                  }
-                  // lib.optionalAttrs (iCfg.hydraUser != "") {
-                    HYDRA_USER = iCfg.hydraUser;
-                  };
-
-                script = ''
-                  ${lib.optionalString (iCfg.ghTokenFile != null) ''export GITHUB_WEBHOOK_SECRET=$(< "$CREDENTIALS_DIRECTORY"/github-token)''}
-                  ${lib.optionalString (iCfg.ghAppKeyFile != null) ''export GITHUB_APP_KEY_FILE="$CREDENTIALS_DIRECTORY"/github-app-key-file''}
-                  ${lib.optionalString (iCfg.hydraPassFile != null) ''export HYDRA_PASS=$(< "$CREDENTIALS_DIRECTORY"/hydra-pass)''}
-                  ${lib.optionalString (iCfg.ghSecretFile != null) ''export KEY=$(< "$CREDENTIALS_DIRECTORY"/github-secret)''}
-
-                  export HYDRA_STATE_DIR="$STATE_DIRECTORY"
-
-                  exec ${lib.getExe iCfg.package}
-                '';
-              }
-          )
-          // lib.optionalAttrs (lib.any (iCfg: iCfg.waitForHydraServerPort) (lib.attrValues cfg)) {
-            # Delay systemd's dependencies until Hydra actually listens.
-            # This is needed for After= ordering of the github-hydra-bridge
-            # because that tries to log in to use Hydra's API when it starts.
-            hydra-server.postStart = let
-              script = pkgs.writeShellApplication {
-                name = "hydra-wait-for-port";
-                runtimeInputs = [pkgs.netcat];
-                text = ''
-                  while ! nc -z localhost ${toString config.services.hydra.port} 2> /dev/null; do
-                    sleep 1
-                  done
-                '';
-              };
-            in ''
-              timeout 30 ${lib.getExe script}
-            '';
+      options.services.hydra-github-bridge = with lib; {
+        enable =
+          mkEnableOption "hydra github bridge"
+          // {
+            default = true;
           };
 
-        targets.hydra-github-bridge = rec {
-          wantedBy = ["hydra-server.service"];
-          after = wantedBy;
+        package = mkOption {
+          type = types.package;
+          default = perSystem.config.packages.hydra-github-bridge;
+          defaultText = "hydra-github-bridge";
+          description = "The hydra to github webhook bridge";
+        };
+
+        ghAppId = mkOption {
+          type = types.int;
+          default = 0;
+          description = ''
+            The GitHub App ID to sign authentication JWTs with.
+          '';
+        };
+
+        ghAppInstallIds = mkOption {
+          type = types.attrsOf types.int;
+          default = {};
+          description = ''
+            Mapping of organization names to GitHub App installation ids to
+            authenticate with.
+          '';
+        };
+
+        ghUserAgent = mkOption {
+          type = types.str;
+          default = null;
+          description = ''
+            The user agent to use for authorization with the GitHub API.
+            This must match the app name if you authenticate using a GitHub App token.
+          '';
+        };
+
+        ghAppKeyFile = mkOption {
+          type = types.path;
+          default = "";
+          description = ''
+            Path to a file containing the GitHub App private key for authorization with GitHub.
+          '';
+        };
+
+        ghTokenFile = mkOption {
+          type = with types; nullOr path;
+          default = null;
+          description = ''
+            Path to a file containing the GitHub token for authorization with GitHub.
+          '';
+        };
+
+        ghSecretFile = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          description = ''
+            The agreed upon secret with GitHub for the Webhook payloads.
+          '';
+        };
+
+        hydraHost = mkOption {
+          type = types.str;
+          example = "http://hydra.example.com:8080";
+          default = "localhost";
+          description = ''
+            The host or URL of hydra.
+          '';
+        };
+
+        hydraUser = mkOption {
+          type = types.str;
+          default = "";
+          description = ''
+            The user to authenticate as with hydra.
+          '';
+        };
+
+        hydraPassFile = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          description = ''
+            A file containing the password to authenticate with against hydra.
+          '';
+        };
+
+        hydraDb = mkOption {
+          type = types.str;
+          default = "";
+          description = ''
+            Hydra DB host string. Empty means unix socket.
+          '';
+        };
+
+        port = mkOption {
+          type = types.port;
+          default = 8811;
+          description = ''
+            The port to listen on for webhooks.
+          '';
+        };
+
+        environmentFile = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          description = ''
+            plaintext environment file, containing and `HYDRA_DB_USER`, and `HYDRA_DB_PASS`.
+          '';
+        };
+
+        waitForHydraServerPort =
+          mkEnableOption ''
+            delay of hydra-server started state until its port is ready.
+            Note this adds an ExecStartPost= to hydra-server.
+            It does not make the hydra-github-bridge wait as the name might suggest.
+          ''
+          // {
+            default = true;
+          };
+      };
+
+      config = lib.mkIf cfg.enable {
+        systemd.services = {
+          hydra-github-bridge = {
+            wantedBy = ["hydra-server.service"];
+            after = ["postgresql.service" "hydra-server.service"];
+
+            startLimitIntervalSec = 0;
+
+            serviceConfig =
+              {
+                User = config.users.users.hydra.name;
+                Group = config.users.groups.hydra.name;
+
+                Restart = "always";
+                RestartSec = "10s";
+
+                LoadCredential =
+                  lib.optional (cfg.ghTokenFile != null) "github-token:${cfg.ghTokenFile}"
+                  ++ lib.optional (cfg.ghAppKeyFile != null) "github-app-key-file:${cfg.ghAppKeyFile}"
+                  ++ lib.optional (cfg.hydraPassFile != null) "hydra-pass:${cfg.hydraPassFile}"
+                  ++ lib.optional (cfg.ghSecretFile != null) "github-secret:${cfg.ghSecretFile}";
+
+                StateDirectory = "hydra";
+              }
+              // lib.optionalAttrs (cfg.environmentFile != null)
+              {EnvironmentFile = builtins.toPath cfg.environmentFile;};
+
+            environment =
+              {
+                HYDRA_HOST = cfg.hydraHost;
+                HYDRA_DB = cfg.hydraDb;
+                PORT = toString cfg.port;
+              }
+              // lib.optionalAttrs (cfg.ghUserAgent != "") {
+                GITHUB_USER_AGENT = cfg.ghUserAgent;
+              }
+              // lib.optionalAttrs (cfg.ghAppId != 0) {
+                GITHUB_APP_ID = toString cfg.ghAppId;
+              }
+              // lib.optionalAttrs (cfg.ghAppInstallIds != {}) {
+                GITHUB_APP_INSTALL_IDS = let
+                  mkPairStr = org: installId: "${org}=${builtins.toString installId}";
+                in
+                  lib.pipe cfg.ghAppInstallIds [
+                    (lib.mapAttrsToList mkPairStr)
+                    (lib.concatStringsSep ",")
+                  ];
+              }
+              // lib.optionalAttrs (cfg.hydraUser != "") {
+                HYDRA_USER = cfg.hydraUser;
+              };
+
+            script = ''
+              ${lib.optionalString (cfg.ghTokenFile != null) ''export GITHUB_WEBHOOK_SECRET=$(< "$CREDENTIALS_DIRECTORY"/github-token)''}
+              ${lib.optionalString (cfg.ghAppKeyFile != null) ''export GITHUB_APP_KEY_FILE="$CREDENTIALS_DIRECTORY"/github-app-key-file''}
+              ${lib.optionalString (cfg.hydraPassFile != null) ''export HYDRA_PASS=$(< "$CREDENTIALS_DIRECTORY"/hydra-pass)''}
+              ${lib.optionalString (cfg.ghSecretFile != null) ''export KEY=$(< "$CREDENTIALS_DIRECTORY"/github-secret)''}
+
+              export HYDRA_STATE_DIR="$STATE_DIRECTORY"
+
+              exec ${lib.getExe cfg.package}
+            '';
+          };
+        }
+        // lib.optionalAttrs cfg.waitForHydraServerPort {
+          # Delay systemd's dependencies until Hydra actually listens.
+          # This is needed for After= ordering of the github-hydra-bridge
+          # because that tries to log in to use Hydra's API when it starts.
+          hydra-server.postStart = let
+            script = pkgs.writeShellApplication {
+              name = "hydra-wait-for-port";
+              runtimeInputs = [pkgs.netcat];
+              text = ''
+                while ! nc -z localhost ${toString config.services.hydra.port} 2> /dev/null; do
+                  sleep 1
+                done
+              '';
+            };
+          in ''
+            timeout 30 ${lib.getExe script}
+          '';
         };
       };
     });

--- a/flake/nixosModules.nix
+++ b/flake/nixosModules.nix
@@ -9,11 +9,7 @@
       cfg = config.services.hydra-github-bridge;
     in {
       options.services.hydra-github-bridge = with lib; {
-        enable =
-          mkEnableOption "hydra github bridge"
-          // {
-            default = true;
-          };
+        enable = mkEnableOption "hydra github bridge";
 
         package = mkOption {
           type = types.package;
@@ -24,7 +20,6 @@
 
         ghAppId = mkOption {
           type = types.int;
-          default = 0;
           description = ''
             The GitHub App ID to sign authentication JWTs with.
           '';
@@ -32,35 +27,16 @@
 
         ghAppInstallIds = mkOption {
           type = types.attrsOf types.int;
-          default = {};
           description = ''
             Mapping of organization names to GitHub App installation ids to
             authenticate with.
           '';
         };
 
-        ghUserAgent = mkOption {
-          type = types.str;
-          default = null;
-          description = ''
-            The user agent to use for authorization with the GitHub API.
-            This must match the app name if you authenticate using a GitHub App token.
-          '';
-        };
-
         ghAppKeyFile = mkOption {
           type = types.path;
-          default = "";
           description = ''
             Path to a file containing the GitHub App private key for authorization with GitHub.
-          '';
-        };
-
-        ghTokenFile = mkOption {
-          type = with types; nullOr path;
-          default = null;
-          description = ''
-            Path to a file containing the GitHub token for authorization with GitHub.
           '';
         };
 
@@ -69,6 +45,15 @@
           default = null;
           description = ''
             The agreed upon secret with GitHub for the Webhook payloads.
+          '';
+        };
+
+        ghUserAgent = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = ''
+            The user agent to use for authorization with the GitHub API.
+            This must match the app name if you authenticate using a GitHub App token.
           '';
         };
 
@@ -133,87 +118,83 @@
       };
 
       config = lib.mkIf cfg.enable {
-        systemd.services = {
-          hydra-github-bridge = {
-            wantedBy = ["hydra-server.service"];
-            after = ["postgresql.service" "hydra-server.service"];
+        systemd.services =
+          {
+            hydra-github-bridge = {
+              wantedBy = ["hydra-server.service"];
+              after = ["postgresql.service" "hydra-server.service"];
 
-            startLimitIntervalSec = 0;
+              startLimitIntervalSec = 0;
 
-            serviceConfig =
-              {
-                User = config.users.users.hydra.name;
-                Group = config.users.groups.hydra.name;
+              serviceConfig =
+                {
+                  User = config.users.users.hydra.name;
+                  Group = config.users.groups.hydra.name;
 
-                Restart = "always";
-                RestartSec = "10s";
+                  Restart = "always";
+                  RestartSec = "10s";
 
-                LoadCredential =
-                  lib.optional (cfg.ghTokenFile != null) "github-token:${cfg.ghTokenFile}"
-                  ++ lib.optional (cfg.ghAppKeyFile != null) "github-app-key-file:${cfg.ghAppKeyFile}"
-                  ++ lib.optional (cfg.hydraPassFile != null) "hydra-pass:${cfg.hydraPassFile}"
-                  ++ lib.optional (cfg.ghSecretFile != null) "github-secret:${cfg.ghSecretFile}";
+                  LoadCredential =
+                    ["github-app-key-file:${cfg.ghAppKeyFile}"]
+                    ++ lib.optional (cfg.hydraPassFile != null) "hydra-pass:${cfg.hydraPassFile}"
+                    ++ lib.optional (cfg.ghSecretFile != null) "github-secret:${cfg.ghSecretFile}";
 
-                StateDirectory = "hydra";
-              }
-              // lib.optionalAttrs (cfg.environmentFile != null)
-              {EnvironmentFile = builtins.toPath cfg.environmentFile;};
+                  StateDirectory = "hydra";
+                }
+                // lib.optionalAttrs (cfg.environmentFile != null)
+                {EnvironmentFile = builtins.toPath cfg.environmentFile;};
 
-            environment =
-              {
-                HYDRA_HOST = cfg.hydraHost;
-                HYDRA_DB = cfg.hydraDb;
-                PORT = toString cfg.port;
-              }
-              // lib.optionalAttrs (cfg.ghUserAgent != "") {
-                GITHUB_USER_AGENT = cfg.ghUserAgent;
-              }
-              // lib.optionalAttrs (cfg.ghAppId != 0) {
-                GITHUB_APP_ID = toString cfg.ghAppId;
-              }
-              // lib.optionalAttrs (cfg.ghAppInstallIds != {}) {
-                GITHUB_APP_INSTALL_IDS = let
-                  mkPairStr = org: installId: "${org}=${builtins.toString installId}";
-                in
-                  lib.pipe cfg.ghAppInstallIds [
-                    (lib.mapAttrsToList mkPairStr)
-                    (lib.concatStringsSep ",")
-                  ];
-              }
-              // lib.optionalAttrs (cfg.hydraUser != "") {
-                HYDRA_USER = cfg.hydraUser;
-              };
+              environment =
+                {
+                  GITHUB_APP_ID = toString cfg.ghAppId;
+                  HYDRA_HOST = cfg.hydraHost;
+                  HYDRA_DB = cfg.hydraDb;
+                  PORT = toString cfg.port;
 
-            script = ''
-              ${lib.optionalString (cfg.ghTokenFile != null) ''export GITHUB_WEBHOOK_SECRET=$(< "$CREDENTIALS_DIRECTORY"/github-token)''}
-              ${lib.optionalString (cfg.ghAppKeyFile != null) ''export GITHUB_APP_KEY_FILE="$CREDENTIALS_DIRECTORY"/github-app-key-file''}
-              ${lib.optionalString (cfg.hydraPassFile != null) ''export HYDRA_PASS=$(< "$CREDENTIALS_DIRECTORY"/hydra-pass)''}
-              ${lib.optionalString (cfg.ghSecretFile != null) ''export KEY=$(< "$CREDENTIALS_DIRECTORY"/github-secret)''}
+                  GITHUB_APP_INSTALL_IDS = let
+                    mkPairStr = org: installId: "${org}=${builtins.toString installId}";
+                  in
+                    lib.pipe cfg.ghAppInstallIds [
+                      (lib.mapAttrsToList mkPairStr)
+                      (lib.concatStringsSep ",")
+                    ];
+                }
+                // lib.optionalAttrs (cfg.ghUserAgent != null) {
+                  GITHUB_USER_AGENT = cfg.ghUserAgent;
+                }
+                // lib.optionalAttrs (cfg.hydraUser != "") {
+                  HYDRA_USER = cfg.hydraUser;
+                };
 
-              export HYDRA_STATE_DIR="$STATE_DIRECTORY"
+              script = ''
+                export GITHUB_APP_KEY_FILE="$CREDENTIALS_DIRECTORY"/github-app-key-file
+                ${lib.optionalString (cfg.ghSecretFile != null) ''export GITHUB_WEBHOOK_SECRET=$(< "$CREDENTIALS_DIRECTORY"/github-secret)''}
+                ${lib.optionalString (cfg.hydraPassFile != null) ''export HYDRA_PASS=$(< "$CREDENTIALS_DIRECTORY"/hydra-pass)''}
 
-              exec ${lib.getExe cfg.package}
-            '';
-          };
-        }
-        // lib.optionalAttrs cfg.waitForHydraServerPort {
-          # Delay systemd's dependencies until Hydra actually listens.
-          # This is needed for After= ordering of the github-hydra-bridge
-          # because that tries to log in to use Hydra's API when it starts.
-          hydra-server.postStart = let
-            script = pkgs.writeShellApplication {
-              name = "hydra-wait-for-port";
-              runtimeInputs = [pkgs.netcat];
-              text = ''
-                while ! nc -z localhost ${toString config.services.hydra.port} 2> /dev/null; do
-                  sleep 1
-                done
+                export HYDRA_STATE_DIR="$STATE_DIRECTORY"
+
+                exec ${lib.getExe cfg.package}
               '';
             };
-          in ''
-            timeout 30 ${lib.getExe script}
-          '';
-        };
+          }
+          // lib.optionalAttrs cfg.waitForHydraServerPort {
+            # Delay systemd's dependencies until Hydra actually listens.
+            # This is needed for After= ordering of the github-hydra-bridge
+            # because that tries to log in to use Hydra's API when it starts.
+            hydra-server.postStart = let
+              script = pkgs.writeShellApplication {
+                name = "hydra-wait-for-port";
+                runtimeInputs = [pkgs.netcat];
+                text = ''
+                  while ! nc -z localhost ${toString config.services.hydra.port} 2> /dev/null; do
+                    sleep 1
+                  done
+                '';
+              };
+            in ''
+              timeout 30 ${lib.getExe script}
+            '';
+          };
       };
     });
 

--- a/flake/test/default.nix
+++ b/flake/test/default.nix
@@ -51,21 +51,21 @@
             start_all()
 
             # The bridge needs its Hydra user to be created first
-            hydra.systemctl("stop hydra-github-bridge.target")
+            hydra.systemctl("stop hydra-github-bridge.service")
 
             # Wait for Hydra to start
             hydra.wait_for_unit("hydra-server.service")
 
             # Create the bridge user and start the bridge
             hydra.succeed("hydra-create-user bridge --password hydra --role admin")
-            hydra.systemctl("start hydra-github-bridge.target")
+            hydra.systemctl("start hydra-github-bridge.service")
 
             # Wait for GitHub Mock server
             hydra.wait_for_unit("mock-github.service")
             hydra.wait_for_open_port(4010)
 
             # Wait for hydra-github-bridge
-            hydra.wait_for_unit("hydra-github-bridge-all.service")
+            hydra.wait_for_unit("hydra-github-bridge.service")
             hydra.wait_for_open_port(8811, timeout=15)
 
             with subtest("Opening a PR creates check runs"):

--- a/flake/test/setup.nix
+++ b/flake/test/setup.nix
@@ -33,7 +33,6 @@
         "app-key-file"
         {nativeBuildInputs = [pkgs.openssl];}
         "openssl genrsa -out $out";
-      ghTokenFile = pkgs.writeText "gh-secret-file" "secret-token";
       ghSecretFile = pkgs.writeText "gh-secret-file" "secret-token";
       hydraHost = "http://localhost:3000";
       hydraUser = "bridge";

--- a/flake/test/setup.nix
+++ b/flake/test/setup.nix
@@ -20,7 +20,7 @@
       buildMachinesFiles = [];
     };
 
-    hydra-github-bridge.all = {
+    hydra-github-bridge = {
       enable = true;
       ghAppId = 12345;
       ghAppInstallIds = {
@@ -95,5 +95,5 @@
   };
 
   # These will fail until Hydra and Mock GitHub are running
-  systemd.targets.hydra-github-bridge.after = ["mock-github.service"];
+  systemd.services.hydra-github-bridge.after = ["mock-github.service"];
 }


### PR DESCRIPTION
Remove multi-instance support for github bridge hydra-github-bridge supports mapping credentials for different app installations, so there's no need to run multiple instances of the server. This change removes per-instance attrs, so
`services.hydra-github-bridge.xyz = {}` becomes `services.hydra-github-bridge = {}`

I've also addressed multiple small outstanding issues:

 * Remove duplicate option `ghTokenFile`
 * Set `enable = false` by default
 * Fix null/string comparison mismatches
 * Remove defaults on required options