### PR TITLE
fix: recover from hung PostgreSQL LISTEN connection, add notify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 .direnv
 .nixos-test-history
 
+result

--- a/flake/nixosModules.nix
+++ b/flake/nixosModules.nix
@@ -158,6 +158,9 @@
                     Restart = "always";
                     RestartSec = "10s";
 
+                    Type = "notify";
+                    WatchdogSec = "120s";
+
                     LoadCredential =
                       lib.optional (iCfg.ghTokenFile != null) "github-token:${iCfg.ghTokenFile}"
                       ++ lib.optional (iCfg.ghAppKeyFile != null) "github-app-key-file:${iCfg.ghAppKeyFile}"

--- a/hydra-github-bridge/hydra-github-bridge.cabal
+++ b/hydra-github-bridge/hydra-github-bridge.cabal
@@ -43,6 +43,8 @@ common common
                     , servant-github-webhook
                     , stm
                     , warp
+    if os(linux)
+      build-depends: systemd
 
 library
     import: common
@@ -51,6 +53,7 @@ library
                       , Lib.Bridge
                       , Lib.Bridge.GitHubToHydra
                       , Lib.Bridge.HydraToGitHub
+                      , Lib.Systemd
                       , Lib.Hydra
                       , Lib.Hydra.Client
                       , Lib.Hydra.DB
@@ -65,10 +68,11 @@ executable hydra-github-bridge
     import:           common
     ghc-options:      -threaded -rtsopts
     hs-source-dirs:   app, src
-    other-modules:      Lib 
+    other-modules:      Lib
                       , Lib.Bridge
                       , Lib.Bridge.GitHubToHydra
                       , Lib.Bridge.HydraToGitHub
+                      , Lib.Systemd
                       , Lib.GitHub
                       , Lib.GitHub.Client
                       , Lib.GitHub.WebHookServer

--- a/hydra-github-bridge/src/Lib/Bridge/HydraToGitHub.hs
+++ b/hydra-github-bridge/src/Lib/Bridge/HydraToGitHub.hs
@@ -78,6 +78,7 @@ import Lib.GitHub (CheckRunConclusion, TokenLease)
 import Lib.GitHub qualified as GitHub
 import Lib.Hydra (BuildStatus)
 import Lib.Hydra qualified as Hydra
+import Lib.Systemd (notifyReady, notifyWatchdog)
 import Network.HTTP.Client qualified as HTTP
 import System.FilePath
   ( takeFileName,
@@ -89,6 +90,7 @@ import System.IO.Error
     ioeGetErrorType,
     isDoesNotExistErrorType,
   )
+import System.Timeout (timeout)
 import Text.Regex.TDFA ((=~))
 
 -- Text utils
@@ -170,21 +172,29 @@ notificationWatcher conn = do
     _ <- execute_ conn "LISTEN build_started" -- (build id)
     _ <- execute_ conn "LISTEN build_finished" -- (build id, dependent build ids...)
     _ <- execute_ conn "LISTEN cached_build_finished" -- (eval id, build id)
+    void notifyReady
     forever $ do
       putStrLn "Waiting for notification..."
-      note <- toHydraNotification . traceShowId <$> getNotification conn
-      statuses <- handleHydraNotification conn (cs host) stateDir note
-      forM_ statuses $
-        ( \(GitHub.CheckRun owner repo payload) -> do
-            liftIO $ Text.putStrLn $ "QUEUEING [" <> owner <> "/" <> repo <> "/" <> payload.headSha <> "] " <> payload.name <> ":" <> Text.pack (show payload.status)
-            [Only _id'] <-
-              query
-                conn
-                "with status_upsert as (insert into github_status (owner, repo, headSha, name) values (?, ?, ?, ?) on conflict (owner, repo, headSha, name) do update set name = excluded.name returning id) insert into github_status_payload (status_id, payload) select (select id from status_upsert), ? returning id"
-                (owner, repo, payload.headSha, payload.name, (toJSON payload)) ::
-                IO [Only Int]
-            execute_ conn "NOTIFY github_status"
-        )
+      -- Bound the blocking wait so a silently-hung PostgreSQL connection is
+      -- detected within the watchdog interval rather than blocking indefinitely.
+      mRaw <- timeout (60 * 1000000) (getNotification conn)
+      case mRaw of
+        Nothing -> pure ()
+        Just raw -> do
+          let note = toHydraNotification (traceShowId raw)
+          statuses <- handleHydraNotification conn (cs host) stateDir note
+          forM_ statuses $
+            ( \(GitHub.CheckRun owner repo payload) -> do
+                liftIO $ Text.putStrLn $ "QUEUEING [" <> owner <> "/" <> repo <> "/" <> payload.headSha <> "] " <> payload.name <> ":" <> Text.pack (show payload.status)
+                [Only _id'] <-
+                  query
+                    conn
+                    "with status_upsert as (insert into github_status (owner, repo, headSha, name) values (?, ?, ?, ?) on conflict (owner, repo, headSha, name) do update set name = excluded.name returning id) insert into github_status_payload (status_id, payload) select (select id from status_upsert), ? returning id"
+                    (owner, repo, payload.headSha, payload.name, (toJSON payload)) ::
+                    IO [Only Int]
+                execute_ conn "NOTIFY github_status"
+            )
+      void notifyWatchdog
 
 statusHandlers :: Connection -> HydraToGitHubT IO ()
 statusHandlers conn = do

--- a/hydra-github-bridge/src/Lib/Systemd.hs
+++ b/hydra-github-bridge/src/Lib/Systemd.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+
+module Lib.Systemd (notifyReady, notifyWatchdog) where
+
+#ifdef linux_HOST_OS
+import System.Systemd.Daemon qualified as Systemd
+#endif
+
+notifyReady :: IO ()
+#ifdef linux_HOST_OS
+notifyReady = Systemd.notifyReady >> pure ()
+#else
+notifyReady = pure ()
+#endif
+
+notifyWatchdog :: IO ()
+#ifdef linux_HOST_OS
+notifyWatchdog = Systemd.notifyWatchdog >> pure ()
+#else
+notifyWatchdog = pure ()
+#endif


### PR DESCRIPTION
The notification watcher blocks indefinitely on `getNotification conn`. If the underlying PostgreSQL connection silently hangs (e.g. due to a dead TCP connection), the loop stalls permanently - the service appears running to systemd but stops processing notifications with no log output and no crash.

Changes:
- Wrap `getNotification` in a 60-second timeout in both `notificationWatcher` and `notificationWatcherWithSSE`, so a hung connection cannot block the loop indefinitely.
- Kick the systemd watchdog at the end of each loop iteration via the systemd Haskell package.
- Set `Type=notify` and `WatchdogSec=120s` in the systemd unit. If a full loop iteration does not complete within 120 seconds, systemd will kill and restart the service automatically.