### PR TITLE
Make Hydra Jobset `keepnr` configurable

### DIFF
--- a/flake/nixosModules.nix
+++ b/flake/nixosModules.nix
@@ -90,6 +90,14 @@
           '';
         };
 
+        hydraKeepEvals = mkOption {
+          type = types.int;
+          default = 2;
+          description = ''
+            The number of evaluations to keep when creating or updating jobsets.
+          '';
+        };
+
         port = mkOption {
           type = types.port;
           default = 8811;
@@ -149,6 +157,7 @@
                   GITHUB_APP_ID = toString cfg.ghAppId;
                   HYDRA_HOST = cfg.hydraHost;
                   HYDRA_DB = cfg.hydraDb;
+                  HYDRA_KEEP_EVALS = toString cfg.hydraKeepEvals;
                   PORT = toString cfg.port;
 
                   GITHUB_APP_INSTALL_IDS = let

--- a/flake/test/integration.nix
+++ b/flake/test/integration.nix
@@ -84,6 +84,13 @@
                 "jq --exit-status 'map(select(.name == \"pullrequest-1347\")) | length > 0'",
                 timeout=20
               )
+              # Verify it has the desired properties
+              hydra.wait_until_succeeds(
+                "curl -H \"Accept: application/json\" "
+                "http://localhost:3000/jobset/input-output-hk-sample/pullrequest-1347 | "
+                "jq --exit-status '.keepnr == 4'",
+                timeout=15
+              )
 
               # Eval will fail because it can't connect to GitHub. That's okay, it will
               # still report at least two statuses to GitHub (in_progress and completed).
@@ -146,6 +153,13 @@
                 "hydra-cli -H http://localhost:3000 project-show input-output-hk-sample -j | "
                 "jq --exit-status 'map(select(.name == \"main\")) | length > 0'",
                 timeout=20
+              )
+              # Verify it has the desired properties
+              hydra.wait_until_succeeds(
+                "curl -H \"Accept: application/json\" "
+                "http://localhost:3000/jobset/input-output-hk-sample/main | "
+                "jq --exit-status '.keepnr == 4'",
+                timeout=15
               )
 
               # Verify an eval/build was triggered

--- a/flake/test/setup.nix
+++ b/flake/test/setup.nix
@@ -33,6 +33,7 @@
       hydraHost = "http://localhost:3000";
       hydraUser = "bridge";
       hydraPassFile = pkgs.writeText "hydra-pass-file" "hydra";
+      hydraKeepEvals = 4;
       port = 8811;
       waitForHydraServerPort = true;
       environmentFile = pkgs.writeText "env" ''

--- a/hydra-github-bridge/app/Main.hs
+++ b/hydra-github-bridge/app/Main.hs
@@ -52,14 +52,15 @@ main = do
   api_pass <- maybe mempty Text.pack <$> lookupEnv "HYDRA_PASS"
   port <- maybe 8080 read <$> lookupEnv "PORT"
   stateDir <- getEnv "HYDRA_STATE_DIR"
+  hydraKeepEvals <- maybe 2 read <$> lookupEnv "HYDRA_KEEP_EVALS"
+
   ghEndpointUrl <- maybe "https://api.github.com" cs <$> lookupEnv "GITHUB_ENDPOINT_URL"
   ghUserAgent <- maybe "hydra-github-bridge" cs <$> lookupEnv "GITHUB_USER_AGENT"
   ghKey <- maybe mempty C8.pack <$> lookupEnv "GITHUB_WEBHOOK_SECRET"
-
-  -- Authenticate to GitHub
   ghAppId <- read <$> getEnv "GITHUB_APP_ID"
   ghAppKeyFile <- getEnv "GITHUB_APP_KEY_FILE"
 
+  -- Authenticate to GitHub
   ghAppInstallIds <- getGhAppInstallIds
 
   ghTokens <- fetchGitHubTokens ghAppId ghAppKeyFile ghEndpointUrl ghUserAgent ghAppInstallIds
@@ -88,7 +89,8 @@ main = do
         GitHubToHydraEnv
           { gthEnvHydraClient = hceClientEnv env,
             gthEnvGitHubKey = gitHubKey ghKey,
-            gthEnvGhAppInstallIds = ghAppInstallIds
+            gthEnvGhAppInstallIds = ghAppInstallIds,
+            gthEnvKeepEvals = hydraKeepEvals
           }
 
   Async.mapConcurrently_

--- a/hydra-github-bridge/src/Lib/Bridge/GitHubToHydra.hs
+++ b/hydra-github-bridge/src/Lib/Bridge/GitHubToHydra.hs
@@ -96,7 +96,8 @@ import Text.Read (readMaybe)
 data GitHubToHydraEnv = GitHubToHydraEnv
   { gthEnvHydraClient :: ClientEnv,
     gthEnvGitHubKey :: GitHubKey,
-    gthEnvGhAppInstallIds :: [(Text, Int)]
+    gthEnvGhAppInstallIds :: [(Text, Int)],
+    gthEnvKeepEvals :: Int
   }
 
 newtype GitHubToHydraT m a = GitHubToHydraT
@@ -217,11 +218,14 @@ handleMergeQueuePushed ::
   (Text, Int) ->
   GitHubToHydraT io ()
 handleMergeQueuePushed conn pushEvent headSha (targetBranch, pullReqNumber) = do
+  keepEvals <- asks (.gthEnvKeepEvals)
+
   let owner = hookRepoOwner pushEvent.evPushRepository
       projName = escapeHydraName pushEvent.evPushRepository.whRepoFullName
       jobset =
         Hydra.defHydraFlakeJobset
-          { Hydra.hjName = "merge-queue-" <> Text.show pullReqNumber,
+          { Hydra.hjKeepnr = keepEvals,
+            Hydra.hjName = "merge-queue-" <> Text.show pullReqNumber,
             Hydra.hjDescription = "Merge Queue: PR" <> Text.show pullReqNumber <> " -> " <> targetBranch,
             Hydra.hjFlake = "github:" <> pushEvent.evPushRepository.whRepoFullName <> "/" <> headSha
           }
@@ -256,6 +260,8 @@ handlePushBranch ::
   Text ->
   GitHubToHydraT io ()
 handlePushBranch conn pushEvent headSha = do
+  keepEvals <- asks (.gthEnvKeepEvals)
+
   let owner = hookRepoOwner pushEvent.evPushRepository
       refName =
         fromMaybe
@@ -264,7 +270,8 @@ handlePushBranch conn pushEvent headSha = do
       jobsetName = escapeHydraName refName
       jobset =
         Hydra.defHydraFlakeJobset
-          { Hydra.hjName = jobsetName,
+          { Hydra.hjKeepnr = keepEvals,
+            Hydra.hjName = jobsetName,
             Hydra.hjDescription =
               refName
                 <> " "
@@ -382,13 +389,16 @@ handlePullRequestUpdated ::
   PullRequestEvent ->
   GitHubToHydraT io ()
 handlePullRequestUpdated conn prEvent = do
+  keepEvals <- asks (.gthEnvKeepEvals)
+
   let owner = hookRepoOwner prEvent.evPullReqRepo
       projName = escapeHydraName prEvent.evPullReqRepo.whRepoFullName
       jobsetName = "pullrequest-" <> Text.show prEvent.evPullReqNumber
 
       jobset =
         Hydra.defHydraFlakeJobset
-          { Hydra.hjName = "pullrequest-" <> Text.show prEvent.evPullReqNumber,
+          { Hydra.hjKeepnr = keepEvals,
+            Hydra.hjName = "pullrequest-" <> Text.show prEvent.evPullReqNumber,
             Hydra.hjDescription =
               "PR "
                 <> Text.show prEvent.evPullReqNumber

--- a/hydra-github-bridge/src/Lib/Bridge/GitHubToHydra.hs
+++ b/hydra-github-bridge/src/Lib/Bridge/GitHubToHydra.hs
@@ -69,7 +69,7 @@ import GitHub.Data.Webhooks.Payload
     PullRequestTarget (..),
   )
 import Lib.GitHub (GitHubKey, SingleHookEndpointAPI)
-import Lib.Hydra (Command, HydraClientEnv)
+import Lib.Hydra (Command, HydraClientEnv, HydraJobset)
 import Lib.Hydra qualified as Hydra
 import Network.HTTP.Client (newManager)
 import Network.HTTP.Client.TLS (tlsManagerSettings)
@@ -648,7 +648,23 @@ hydraClient henv@Hydra.HydraClientEnv {hceClientEnv} conn =
         Right _ -> pure ()
 
 handleCmd :: HydraClientEnv -> Command -> ClientM ()
-handleCmd Hydra.HydraClientEnv {..} (Hydra.CreateOrUpdateJobset repoName projName jobsetName jobset) = do
+handleCmd env = \case
+  Hydra.CreateOrUpdateJobset repo proj jobsetName jobset ->
+    handleCmdUpsertJobset env repo proj jobsetName jobset
+  Hydra.UpdateJobset repo proj jobsetName jobset ->
+    handleCmdUpdateJobset env repo proj jobsetName jobset
+  Hydra.DeleteJobset projName jobsetName -> handleCmdDeleteJobset projName jobsetName
+  Hydra.EvaluateJobset proj jobset force -> handleCmdEvaluateJobset env proj jobset force
+  Hydra.RestartBuild buildId -> handleCmdRestartBuild buildId
+
+handleCmdUpsertJobset ::
+  HydraClientEnv ->
+  Text ->
+  Text ->
+  Text ->
+  HydraJobset ->
+  ClientM ()
+handleCmdUpsertJobset Hydra.HydraClientEnv {..} repoName projName jobsetName jobset = do
   liftIO (putStrLn $ "Processing Create/Update " ++ show projName ++ "/" ++ show jobsetName ++ " from the queue.")
   void $
     Hydra.mkJobset projName jobsetName jobset `on404` do
@@ -667,8 +683,15 @@ handleCmd Hydra.HydraClientEnv {..} (Hydra.CreateOrUpdateJobset repoName projNam
 
   liftIO (putStrLn $ "Processing Update " ++ show projName ++ "/" ++ show jobsetName ++ " triggering push...")
   void $ Hydra.push (Just hceHost) (Just (projName <> ":" <> jobsetName)) Nothing
-  return ()
-handleCmd Hydra.HydraClientEnv {..} (Hydra.UpdateJobset repoName projName jobsetName jobset) = do
+
+handleCmdUpdateJobset ::
+  HydraClientEnv ->
+  Text ->
+  Text ->
+  Text ->
+  HydraJobset ->
+  ClientM ()
+handleCmdUpdateJobset Hydra.HydraClientEnv {..} repoName projName jobsetName jobset = do
   liftIO (putStrLn $ "Processing Update " ++ show projName ++ "/" ++ show jobsetName ++ " from the queue.")
   -- ensure we try to get this first, ...
   void $ Hydra.getJobset projName jobsetName
@@ -686,22 +709,33 @@ handleCmd Hydra.HydraClientEnv {..} (Hydra.UpdateJobset repoName projName jobset
               }
           )
       Hydra.mkJobset projName jobsetName jobset
-
   -- or triggering an eval
   liftIO (putStrLn $ "Processing Update " ++ show projName ++ "/" ++ show jobsetName ++ " triggering push...")
   void $ Hydra.push (Just hceHost) (Just (projName <> ":" <> jobsetName)) Nothing
-  return ()
-handleCmd _ (Hydra.DeleteJobset projName jobsetName) = do
+
+handleCmdDeleteJobset ::
+  Text ->
+  Text ->
+  ClientM ()
+handleCmdDeleteJobset projName jobsetName =
   void $ Hydra.rmJobset projName jobsetName
-  return ()
-handleCmd Hydra.HydraClientEnv {..} (Hydra.EvaluateJobset projName jobsetName force) = do
+
+handleCmdEvaluateJobset ::
+  HydraClientEnv ->
+  Text ->
+  Text ->
+  Bool ->
+  ClientM ()
+handleCmdEvaluateJobset Hydra.HydraClientEnv {..} projName jobsetName force = do
   liftIO (putStrLn $ "Processing Eval " ++ show projName ++ "/" ++ show jobsetName ++ " from the queue. Triggering push...")
   void $ Hydra.push (Just hceHost) (Just (projName <> ":" <> jobsetName)) (Just force)
-  return ()
-handleCmd _ (Hydra.RestartBuild bid) = do
-  liftIO (putStrLn $ "Processing Restart " ++ show bid ++ " from the queue. Triggering restart...")
-  void $ Hydra.restartBuild $ bid
-  return ()
+
+handleCmdRestartBuild ::
+  Int ->
+  ClientM ()
+handleCmdRestartBuild buildId = do
+  liftIO (putStrLn $ "Processing Restart " ++ show buildId ++ " from the queue. Triggering restart...")
+  void $ Hydra.restartBuild buildId
 
 -- combinator for handing 404 (not found)
 on404 :: ClientM a -> ClientM a -> ClientM a


### PR DESCRIPTION
Currently, we always create or update jobsets with `keepnr` set to 2. However, that value could be frequently updated or vary from installation to installation.

Instead, make it a default of 2, allowing it to be overridden by the NixOS module or by setting an environment variable.

Resolves: #34