### PR TITLE
Add a watchdog monitor thread that logs diagnostics

### DIFF
--- a/hydra-github-bridge/app/Main.hs
+++ b/hydra-github-bridge/app/Main.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -8,13 +9,22 @@ module Main where
 
 import Control.Concurrent.Async as Async
 import Data.ByteString.Char8 qualified as C8
+import Data.Functor (void)
 import Data.IORef (newIORef)
 import Data.Maybe (fromMaybe)
 import Data.String.Conversions (cs)
 import Data.Text (Text)
 import Data.Text qualified as Text
+import Data.Time (secondsToNominalDiffTime)
 import Database.PostgreSQL.Simple
-import Lib.Bridge.GitHubToHydra (GitHubToHydraEnv (..), app, hydraClient, hydraClientEnv, parseInstallIds)
+import Lib.Bridge.GitHubToHydra
+  ( GitHubToHydraEnv (..),
+    app,
+    hydraClient,
+    hydraClientEnv,
+    parseInstallIds,
+    runApp,
+  )
 import Lib.Bridge.HydraToGitHub
   ( HydraToGitHubEnv (..),
     fetchGitHubTokens,
@@ -22,9 +32,9 @@ import Lib.Bridge.HydraToGitHub
     runHydraToGitHubT,
     statusHandlers,
   )
+import Lib.Bridge.Watchdog (WatchdogEnv (..), mkWatchdogEnv, watchdog)
 import Lib.GitHub (gitHubKey)
 import Lib.Hydra (HydraClientEnv (..))
-import Network.Wai.Handler.Warp (run)
 import System.Environment (getEnv, lookupEnv)
 import System.Exit (die)
 import System.IO (BufferMode (..), hSetBuffering, stderr, stdin, stdout)
@@ -93,21 +103,32 @@ main = do
             gthEnvKeepEvals = hydraKeepEvals
           }
 
+      watchdogInterval = secondsToNominalDiffTime 60
+      idleThreshold = secondsToNominalDiffTime 120
+  watchdogEnv <- mkWatchdogEnv watchdogInterval idleThreshold port
+
+  let heartbeats = watchdogEnv.watchdogHeartbeats
+
+  void . Async.async $
+    withConnect
+      (ConnectInfo db 5432 db_user db_pass "hydra")
+      (watchdog watchdogEnv)
+
   Async.mapConcurrently_
     id
     [ Async.replicateConcurrently_
         numWorkers
         ( withConnect
             (ConnectInfo db 5432 db_user db_pass "hydra")
-            (runHydraToGitHubT hydraToGitHubEnv . statusHandlers)
+            (runHydraToGitHubT hydraToGitHubEnv . statusHandlers heartbeats)
         ),
       withConnect
         (ConnectInfo db 5432 db_user db_pass "hydra")
-        (hydraClient env),
+        (hydraClient heartbeats env),
       withConnect
         (ConnectInfo db 5432 db_user db_pass "hydra")
-        (runHydraToGitHubT hydraToGitHubEnv . notificationWatcher),
+        (runHydraToGitHubT hydraToGitHubEnv . notificationWatcher heartbeats),
       withConnect
         (ConnectInfo db 5432 db_user db_pass "hydra")
-        (run port . app gitHubToHydraEnv)
+        (runApp heartbeats port . app gitHubToHydraEnv)
     ]

--- a/hydra-github-bridge/hydra-github-bridge.cabal
+++ b/hydra-github-bridge/hydra-github-bridge.cabal
@@ -19,6 +19,7 @@ common common
                     , async
                     , bytestring
                     , bz2
+                    , containers
                     , crypton
                     , crypton-x509
                     , crypton-x509-store
@@ -43,6 +44,8 @@ common common
                     , string-conversions
                     , text >= 2
                     , time
+                    , wai
+                    , wai-extra
                     , warp
 
 library
@@ -52,6 +55,7 @@ library
                       , Lib.Bridge
                       , Lib.Bridge.GitHubToHydra
                       , Lib.Bridge.HydraToGitHub
+                      , Lib.Bridge.Watchdog
                       , Lib.Hydra
                       , Lib.Hydra.Client
                       , Lib.Hydra.DB
@@ -70,6 +74,7 @@ executable hydra-github-bridge
                       , Lib.Bridge
                       , Lib.Bridge.GitHubToHydra
                       , Lib.Bridge.HydraToGitHub
+                      , Lib.Bridge.Watchdog
                       , Lib.GitHub
                       , Lib.GitHub.Client
                       , Lib.GitHub.WebHookServer

--- a/hydra-github-bridge/src/Lib/Bridge/GitHubToHydra.hs
+++ b/hydra-github-bridge/src/Lib/Bridge/GitHubToHydra.hs
@@ -11,6 +11,7 @@ module Lib.Bridge.GitHubToHydra
   ( GitHubToHydraEnv (..),
     GitHubToHydraT (..),
     hydraClientEnv,
+    runApp,
     app,
     singleEndpoint,
     pushHook,
@@ -68,13 +69,16 @@ import GitHub.Data.Webhooks.Payload
     HookUser (..),
     PullRequestTarget (..),
   )
-import Lib.GitHub (GitHubKey, SingleHookEndpointAPI)
+import Lib.Bridge.Watchdog (Heartbeats, updateHeartbeat)
+import Lib.GitHub (BridgeAPI, GitHubKey, HealthEndpointAPI, SingleHookEndpointAPI)
 import Lib.Hydra (Command, HydraClientEnv, HydraJobset)
 import Lib.Hydra qualified as Hydra
 import Network.HTTP.Client (newManager)
 import Network.HTTP.Client.TLS (tlsManagerSettings)
 import Network.HTTP.Types (Status (..))
 import Network.URI (parseURI)
+import Network.Wai.Handler.Warp (run)
+import Network.Wai.Middleware.Select (selectMiddleware, selectMiddlewareExceptRawPathInfo)
 import Servant
   ( Application,
     Context (..),
@@ -114,13 +118,34 @@ newtype GitHubToHydraT m a = GitHubToHydraT
 runGitHubToHydraT :: GitHubToHydraEnv -> GitHubToHydraT m a -> m a
 runGitHubToHydraT env (GitHubToHydraT action) = runReaderT action env
 
+runApp :: Heartbeats -> Int -> Application -> IO ()
+runApp heartbeats port app' =
+  -- Populate the webServer heartbeat at startup
+  updateHeartbeat' >> run port (middleware app')
+  where
+    middleware =
+      selectMiddleware $
+        -- Do not update the heartbeat when checking health. Otherwise, it would always
+        -- appear as busy
+        selectMiddlewareExceptRawPathInfo
+          "/health"
+          heartbeatMiddleware
+
+    updateHeartbeat' = updateHeartbeat heartbeats "webServer"
+    heartbeatMiddleware midapp req resp = updateHeartbeat' >> midapp req resp
+
 app :: GitHubToHydraEnv -> Connection -> Application
 app env@GitHubToHydraEnv {gthEnvGitHubKey} conn =
   Servant.serveWithContextT
-    (Proxy :: Proxy SingleHookEndpointAPI)
+    (Proxy :: Proxy BridgeAPI)
     (gthEnvGitHubKey :. EmptyContext)
     (runGitHubToHydraT env)
-    (singleEndpoint conn)
+    (bridgeServer conn)
+
+bridgeServer ::
+  Connection ->
+  ServerT BridgeAPI (GitHubToHydraT Handler)
+bridgeServer conn = singleEndpoint conn :<|> healthEndpoint
 
 singleEndpoint ::
   Connection ->
@@ -131,6 +156,9 @@ singleEndpoint conn =
     :<|> pullRequestHook conn
     :<|> checkSuiteHook conn
     :<|> checkRunHook conn
+
+healthEndpoint :: ServerT HealthEndpointAPI (GitHubToHydraT Handler)
+healthEndpoint = pure (Just "OK")
 
 -- | Handle push event webhooks under the following cases:
 --
@@ -628,10 +656,12 @@ hydraClientEnv host user pass = do
 
   return $ Hydra.HydraClientEnv host' user pass env
 
-hydraClient :: HydraClientEnv -> Connection -> IO ()
-hydraClient henv@Hydra.HydraClientEnv {hceClientEnv} conn =
+hydraClient :: Heartbeats -> HydraClientEnv -> Connection -> IO ()
+hydraClient heartbeats henv@Hydra.HydraClientEnv {hceClientEnv} conn =
   -- loop forever, working down the hydra commands
-  forever $
+  forever $ do
+    updateHeartbeat heartbeats "hydraClient"
+
     Hydra.readCommand conn >>= \cmd -> do
       result <- Servant.runClientM (handleCmd henv cmd) hceClientEnv
       case result of

--- a/hydra-github-bridge/src/Lib/Bridge/HydraToGitHub.hs
+++ b/hydra-github-bridge/src/Lib/Bridge/HydraToGitHub.hs
@@ -71,6 +71,7 @@ import GitHub.REST
     queryGitHub,
   )
 import Lib (binarySearch)
+import Lib.Bridge.Watchdog (Heartbeats, updateHeartbeat)
 import Lib.Data.Duration (humanReadableDuration)
 import Lib.Data.List (takeEnd)
 import Lib.Data.Text (indentLine)
@@ -146,8 +147,8 @@ fetchGitHubTokens ghAppId ghAppKeyFile ghEndpointUrl ghUserAgent ghAppInstallIds
     Text.putStrLn $ "Fetched new GitHub App installation token valid for " <> owner <> " until " <> Text.pack (show lease.expiry)
     return (Text.unpack owner, lease)
 
-notificationWatcher :: Connection -> HydraToGitHubT IO ()
-notificationWatcher conn = do
+notificationWatcher :: Heartbeats -> Connection -> HydraToGitHubT IO ()
+notificationWatcher heartbeats conn = do
   host <- asks htgEnvHydraHost
   stateDir <- asks htgEnvHydraStateDir
 
@@ -162,6 +163,8 @@ notificationWatcher conn = do
     _ <- execute_ conn "LISTEN build_finished" -- (build id, dependent build ids...)
     _ <- execute_ conn "LISTEN cached_build_finished" -- (eval id, build id)
     forever $ do
+      updateHeartbeat heartbeats "notificationWatcher"
+
       putStrLn "Waiting for notification..."
       note <- toHydraNotification . traceShowId <$> getNotification conn
       statuses <- handleHydraNotification conn (cs host) stateDir note
@@ -177,8 +180,8 @@ notificationWatcher conn = do
             execute_ conn "NOTIFY github_status"
         )
 
-statusHandlers :: Connection -> HydraToGitHubT IO ()
-statusHandlers conn = do
+statusHandlers :: Heartbeats -> Connection -> HydraToGitHubT IO ()
+statusHandlers heartbeats conn = do
   ghEndpointUrl <- asks htgEnvGhEndpointUrl
   ghUserAgent <- asks htgEnvGhUserAgent
   env <- ask
@@ -270,6 +273,7 @@ statusHandlers conn = do
             _ -> return False
     _ <- liftIO $ execute_ conn "LISTEN github_status"
     let loop = do
+          liftIO $ updateHeartbeat heartbeats "statusHandlers"
           executed <- liftIO processStatuses
           unless executed $ void $ liftIO $ getNotification conn
           when executed loop

--- a/hydra-github-bridge/src/Lib/Bridge/Watchdog.hs
+++ b/hydra-github-bridge/src/Lib/Bridge/Watchdog.hs
@@ -1,0 +1,158 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE NoFieldSelectors #-}
+
+-- | There's an issue in production that happens every few days where all processing
+-- stalls (notifications, webhooks, and webserver), but the process is still alive. During
+-- this time no log messages are output and the only fix is to restart the process, and
+-- everything continues normally.
+--
+-- The purpose of this module is to diagnose this and other concurrency problems. This
+-- defines a Watchdog that each thread needs to kick on a regular interval. The watchdog
+-- will then report the heartbeat ages and other diagnostics regularly.
+module Lib.Bridge.Watchdog
+  ( WatchdogEnv (..),
+    Heartbeats (..),
+    mkWatchdogEnv,
+    updateHeartbeat,
+    watchdog,
+  )
+where
+
+import Control.Concurrent (threadDelay)
+import Control.Exception (Exception (..), SomeException, try)
+import Control.Monad (forever)
+import Data.Bifunctor (Bifunctor (..))
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
+import Data.List (intersperse)
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Proxy (Proxy (..))
+import Data.String.Conversions (cs)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.IO qualified as Text
+import Data.Time (NominalDiffTime, UTCTime)
+import Data.Time qualified as Time
+import Database.PostgreSQL.Simple (Connection, Only (..), query_)
+import Lib.GitHub.WebHookServer (HealthEndpointAPI)
+import Network.HTTP.Client (defaultManagerSettings, newManager)
+import Servant.Client (ClientEnv, ClientM)
+import Servant.Client qualified as Servant
+import System.Timeout (timeout)
+
+data WatchdogEnv
+  = WatchdogEnv
+  { -- | How often the watchdog runs
+    watchdogInterval :: NominalDiffTime,
+    -- | Heartbeats with their last-updated time
+    watchdogHeartbeats :: Heartbeats,
+    -- | How long between heartbeats do we consider a thread idle
+    watchdogIdleThreshold :: NominalDiffTime,
+    -- | Bridge API HTTP client
+    watchdogBridgeClient :: ClientEnv
+  }
+
+-- | A mapping of thread names to latest updated timestamps
+newtype Heartbeats = Heartbeats {unHeartbeats :: IORef (Map Text UTCTime)}
+
+mkWatchdogEnv :: NominalDiffTime -> NominalDiffTime -> Int -> IO WatchdogEnv
+mkWatchdogEnv interval idleThreshold port = do
+  heartbeats <- Heartbeats <$> newIORef Map.empty
+  webClient <- bridgeClientEnv port
+
+  pure
+    WatchdogEnv
+      { watchdogInterval = interval,
+        watchdogHeartbeats = heartbeats,
+        watchdogIdleThreshold = idleThreshold,
+        watchdogBridgeClient = webClient
+      }
+
+updateHeartbeat :: Heartbeats -> Text -> IO ()
+updateHeartbeat (Heartbeats r) name = do
+  now <- Time.getCurrentTime
+  atomicModifyIORef' r $ \m -> (Map.insert name now m, ())
+
+bridgeClientEnv :: Int -> IO ClientEnv
+bridgeClientEnv port = do
+  mgr <- newManager defaultManagerSettings
+  let url = Servant.BaseUrl Servant.Http "127.0.0.1" port ""
+  pure $ Servant.mkClientEnv mgr url
+
+health :: ClientM (Maybe Text)
+health = Servant.client (Proxy @HealthEndpointAPI)
+
+watchdog :: WatchdogEnv -> Connection -> IO ()
+watchdog env conn = forever $ do
+  threadDelay (toMicros env.watchdogInterval)
+
+  reportHeartbeats env.watchdogIdleThreshold env.watchdogHeartbeats
+  reportDiagnostics env.watchdogBridgeClient conn
+  where
+    toMicros = floor . (* 1_000_000) . Time.nominalDiffTimeToSeconds
+
+reportHeartbeats :: NominalDiffTime -> Heartbeats -> IO ()
+reportHeartbeats idleThreshold (Heartbeats heartbeats) = do
+  now <- Time.getCurrentTime
+  hbs <- readIORef heartbeats
+
+  let hbsText =
+        "Heartbeats " <> showMap (Map.map (Time.diffUTCTime now) hbs)
+
+  Text.putStrLn $
+    "watchdog tick: " <> hbsText
+  where
+    showSeconds :: NominalDiffTime -> Text
+    showSeconds diff =
+      cs (Time.formatTime Time.defaultTimeLocale "%ss" diff)
+        <> if diff > idleThreshold
+          then
+            " [idle]"
+          else ""
+
+    showMap m = "{" <> showMapEntries m <> "}"
+
+    showMapEntries =
+      Text.concat
+        . intersperse ", "
+        . Map.foldrWithKey (\k a b -> (k <> " = " <> showSeconds a) : b) []
+
+reportDiagnostics :: ClientEnv -> Connection -> IO ()
+reportDiagnostics client conn = do
+  -- Check the database connection
+  dbCheck <- try' $ query_ @(Only Int) conn "SELECT 1"
+  let (dbRes, dbCtx) = evalDbCheck dbCheck
+
+  -- Check the web server
+  webCheck <- try' $ Servant.runClientM health client
+  let webCheck' =
+        -- Flatten `Either SomeException (Maybe (Either ClientError t))` to
+        -- `Either SomeException (Maybe t)`
+        mapM (first toException) =<< webCheck
+      (webRes, webCtx) = evalWebCheck webCheck'
+
+  -- Log the results
+  Text.putStrLn $ "watchdog check: DB=" <> dbRes <> ", webServer=" <> webRes
+  case dbCtx of
+    Just ctx -> Text.putStrLn $ "watchdog db: " <> ctx
+    Nothing -> pure ()
+  case webCtx of
+    Just ctx -> Text.putStrLn $ "watchdog webServer: " <> ctx
+    Nothing -> pure ()
+  where
+    try' :: IO a -> IO (Either SomeException (Maybe a))
+    try' = try @SomeException . timeout 5_000_000
+
+    evalDbCheck (Right (Just [Only 1])) = ("OK", Nothing)
+    evalDbCheck (Right (Just unexpected)) = ("INVALID", Just $ Text.show unexpected)
+    evalDbCheck (Right Nothing) = ("TIMEOUT", Nothing)
+    evalDbCheck (Left err) = ("ERROR", Just $ Text.show err)
+
+    evalWebCheck (Right (Just (Just "OK"))) = ("OK", Nothing)
+    evalWebCheck (Right (Just res)) = ("INVALID", Just $ Text.show res)
+    evalWebCheck (Right Nothing) = ("TIMEOUT", Nothing)
+    evalWebCheck (Left err) = ("ERROR", Just $ Text.show err)

--- a/hydra-github-bridge/src/Lib/GitHub/WebHookServer.hs
+++ b/hydra-github-bridge/src/Lib/GitHub/WebHookServer.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
@@ -11,12 +12,15 @@ module Lib.GitHub.WebHookServer
     PullRequestHookAPI,
     CheckSuiteHookAPI,
     SingleHookEndpointAPI,
+    HealthEndpointAPI,
+    BridgeAPI,
     GitHubKey (..),
     gitHubKey,
   )
 where
 
 import Data.ByteString.Char8 (ByteString)
+import Data.Text (Text)
 import GitHub.Data.Webhooks.Events
   ( CheckRunEvent,
     CheckSuiteEvent,
@@ -24,7 +28,7 @@ import GitHub.Data.Webhooks.Events
     PullRequestEvent,
     PushEvent,
   )
-import Servant (Context (..), HasContextEntry (..), JSON, Post, (:<|>), (:>))
+import Servant (Context (..), Get, HasContextEntry (..), JSON, Post, (:<|>), (:>))
 import Servant.GitHub.Webhook (GitHubEvent, GitHubSignedReqBody, RepoWebhookEvent (..))
 import qualified Servant.GitHub.Webhook as GitHub
 
@@ -66,6 +70,10 @@ type SingleHookEndpointAPI =
            :<|> CheckSuiteHookAPI
            :<|> CheckRunHookAPI
        )
+
+type HealthEndpointAPI = "health" :> Get '[JSON] (Maybe Text)
+
+type BridgeAPI = SingleHookEndpointAPI :<|> HealthEndpointAPI
 
 newtype GitHubKey = GitHubKey (forall result. GitHub.GitHubKey result)
 


### PR DESCRIPTION
This change introduces a watchdog thread that periodically reports per-thread heartbeats and other general diagnostics (such as whether we can connect to DB and web-server). Eg,

```
watchdog tick: Heartbeats {hydraClient = 39s, notificationWatcher = 37s, statusHandlers = 37s, webServer = 47s}
watchdog check: DB=OK, webServer=OK
watchdog tick: Heartbeats {hydraClient = 125s [idle], notificationWatcher = 125s [idle], statusHandlers = 125s [idle], webServer = 125s [idle]}
watchdog check: DB=TIMEOUT, webServer=OK
```

It is meant to diagnose a known issue that occurs every few days where processing stalls all workers, but the process is still alive. During this time, no log messages are output and the only fix is to restart the process.

No action is taken, except that logs are written. This change is deliberately small in order to accurately pinpoint the problem.